### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ also can take advantage of `stagger` and `reverse` properties on the `VelocityCo
 
 You will need to manually register the UI Pack with the global Velocity in your application with:
 ```JS
-  require('velocity');
+  require('velocity-animate');
   require('velocity-animate/velocity.ui');
 ```
 


### PR DESCRIPTION
fix typo in README about how to manually register the UI Pack
